### PR TITLE
Update link to Geocoding API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # geocoding-example
 [![Build Status](https://travis-ci.org/mapbox/geocoding-example.svg?branch=master)](https://travis-ci.org/mapbox/geocoding-example)
 
-Examples of how to use the Mapbox geocoder. We do our best to make our [geocoding API simple to understand](https://www.mapbox.com/developers/api/geocoding/). But sometimes it's nice to see example implementations of things like batch geocoding where parallelization and throttling are necessary.
+Examples of how to use the Mapbox geocoder. We do our best to make our [geocoding API simple to understand](https://docs.mapbox.com/api/search/#geocoding). But sometimes it's nice to see example implementations of things like batch geocoding where parallelization and throttling are necessary.
 
 This repo is a work in progress. Don't see your favorite language? [Open a ticket](https://github.com/mapbox/geocoding-example/issues/new)!
 


### PR DESCRIPTION
Old link
https://www.mapbox.com/developers/api/geocoding/

was redirecting to
https://docs.mapbox.com/api/

so I updated to new link to
https://docs.mapbox.com/api/search/#geocoding